### PR TITLE
Rename SDK client class to Listclean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+/.idea/
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,103 @@
-# listclean-php
-Beginner friendly Listclean Official SDK
+# Listclean PHP SDK
+
+A beginner-friendly PHP SDK for the [Listclean API](https://api.listclean.xyz). The SDK wraps the official endpoints so you can verify emails, manage uploads, and monitor account details with simple PHP method calls.
+
+## Requirements
+
+- PHP 7.2 or higher
+- cURL extension enabled (default for most PHP installations)
+- A Listclean API key (available from your Listclean dashboard)
+
+## Installation
+
+Use [Composer](https://getcomposer.org/) to add the SDK to your project:
+
+```bash
+composer require listclean/listclean-php
+```
+
+If you are installing from source, make sure to include the Composer autoloader:
+
+```php
+require __DIR__ . '/vendor/autoload.php';
+```
+
+## Quick start
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use Listclean\Listclean;
+
+$client = new Listclean('your-api-key-here');
+
+// Verify a single email address
+$result = $client->verifyEmail('user@example.com');
+
+if ($result['success'] ?? false) {
+    $status = $result['data'][0]['status'] ?? 'unknown';
+    echo "Status: {$status}" . PHP_EOL;
+}
+```
+
+## API coverage
+
+The SDK currently supports the following endpoints from the OpenAPI specification:
+
+| Feature | Method | Endpoint |
+| ------- | ------ | -------- |
+| Verify a single email | `verifyEmail(string $email)` | `GET /verify/email/{email}` |
+| Verify a batch of emails | `verifyEmailBatch(array $emails)` | `POST /verify/email/batch` |
+| Fetch verification logs | `getVerificationLogs()` | `GET /verify/email/logs` |
+| List uploads | `listUploads()` | `GET /uploads/` |
+| Start an upload | `startUpload(array $payload)` | `POST /uploads/` |
+| Upload a chunk | `uploadChunk(int $uploadId, array $payload)` | `POST /uploads/{upload_id}` |
+| Get upload status | `getUploadStatus(int $uploadId)` | `GET /uploads/{upload_id}` |
+| List all lists | `listLists()` | `GET /lists/` |
+| Get a list | `getList(int $listId)` | `GET /lists/{list_id}` |
+| Delete a list | `deleteList(int $listId)` | `DELETE /lists/{list_id}` |
+| Download list as CSV | `downloadListCsv(int $listId, string $type, ?string $tokenOverride = null)` | `GET /downloads/{list_id}/{type}/` |
+| Download list as JSON | `downloadListJson(int $listId, string $type, ?string $tokenOverride = null)` | `GET /downloads/json/{list_id}/{type}/` |
+| Get account profile | `getProfile()` | `GET /account/profile/` |
+| Update account profile | `updateProfile(array $payload)` | `POST /account/profile/` |
+| Check credits | `getCredits()` | `GET /credits` |
+
+## Handling errors
+
+All methods can throw a `Listclean\Exceptions\ApiException` if something goes wrong (for example, invalid credentials or a malformed request). Catch this exception to inspect the HTTP status code and response body:
+
+```php
+use Listclean\Exceptions\ApiException;
+
+try {
+    $client->verifyEmail('user@example.com');
+} catch (ApiException $exception) {
+    echo 'Status code: ' . $exception->getStatusCode();
+    print_r($exception->getResponseBody());
+}
+```
+
+## Examples
+
+The `examples/` directory contains small scripts that show how to:
+
+- Verify a single email (`examples/verify_single.php`)
+- Verify a batch of emails (`examples/verify_batch.php`)
+- Start an upload and track its progress (`examples/upload_list.php`)
+
+Run an example by setting your API key and executing it with PHP:
+
+```bash
+API_KEY="your-api-key" php examples/verify_single.php
+```
+
+Each example reads the API key from the `API_KEY` environment variable to keep secrets out of source control.
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Run `composer dump-autoload` after adding new classes.
+3. Submit a pull request with a clear description of the changes.
+
+Feel free to open issues for questions or feature requests!

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "listclean/listclean-php",
+    "description": "Beginner friendly PHP SDK for the Listclean API",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Listclean\\": "src/Listclean/"
+        }
+    },
+    "require": {
+        "php": ">=7.2"
+    }
+}

--- a/examples/upload_list.php
+++ b/examples/upload_list.php
@@ -1,0 +1,45 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Listclean\Exceptions\ApiException;
+use Listclean\Listclean;
+
+$apiKey = getenv('API_KEY');
+
+if (!$apiKey) {
+    fwrite(STDERR, "Please set the API_KEY environment variable.\n");
+    exit(1);
+}
+
+$client = new Listclean($apiKey);
+
+$filename = $argv[1] ?? 'my-list.csv';
+$fileType = pathinfo($filename, PATHINFO_EXTENSION) ?: 'csv';
+
+$payload = [
+    'filename' => $filename,
+    'file_type' => $fileType,
+    'total_chunk_count' => 1,
+    'max_chunk_size' => 64000,
+];
+
+try {
+    $startResponse = $client->startUpload($payload);
+    print_r($startResponse);
+
+    $uploadId = $startResponse['data']['upload_id'] ?? null;
+
+    if (!$uploadId) {
+        fwrite(STDERR, "Upload ID not returned by API.\n");
+        exit(1);
+    }
+
+    $status = $client->getUploadStatus((int) $uploadId);
+    print_r($status);
+} catch (ApiException $exception) {
+    fwrite(STDERR, 'Request failed: ' . $exception->getMessage() . PHP_EOL);
+    if ($exception->getResponseBody()) {
+        print_r($exception->getResponseBody());
+    }
+}

--- a/examples/verify_batch.php
+++ b/examples/verify_batch.php
@@ -1,0 +1,30 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Listclean\Exceptions\ApiException;
+use Listclean\Listclean;
+
+$apiKey = getenv('API_KEY');
+
+if (!$apiKey) {
+    fwrite(STDERR, "Please set the API_KEY environment variable.\n");
+    exit(1);
+}
+
+$client = new Listclean($apiKey);
+$emails = array_slice($argv, 1);
+
+if (empty($emails)) {
+    $emails = ['user1@example.com', 'user2@example.com'];
+}
+
+try {
+    $response = $client->verifyEmailBatch($emails);
+    print_r($response);
+} catch (ApiException $exception) {
+    fwrite(STDERR, 'Request failed: ' . $exception->getMessage() . PHP_EOL);
+    if ($exception->getResponseBody()) {
+        print_r($exception->getResponseBody());
+    }
+}

--- a/examples/verify_single.php
+++ b/examples/verify_single.php
@@ -1,0 +1,26 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Listclean\Exceptions\ApiException;
+use Listclean\Listclean;
+
+$apiKey = getenv('API_KEY');
+
+if (!$apiKey) {
+    fwrite(STDERR, "Please set the API_KEY environment variable.\n");
+    exit(1);
+}
+
+$client = new Listclean($apiKey);
+$email = $argv[1] ?? 'user@example.com';
+
+try {
+    $response = $client->verifyEmail($email);
+    print_r($response);
+} catch (ApiException $exception) {
+    fwrite(STDERR, 'Request failed: ' . $exception->getMessage() . PHP_EOL);
+    if ($exception->getResponseBody()) {
+        print_r($exception->getResponseBody());
+    }
+}

--- a/src/Listclean/Exceptions/ApiException.php
+++ b/src/Listclean/Exceptions/ApiException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Listclean\Exceptions;
+
+use Exception;
+
+class ApiException extends Exception
+{
+    /**
+     * @var int|null
+     */
+    protected $statusCode;
+
+    /**
+     * @var array|null
+     */
+    protected $responseBody;
+
+    public function __construct(string $message, ?int $statusCode = null, ?array $responseBody = null)
+    {
+        parent::__construct($message, $statusCode ?? 0);
+        $this->statusCode = $statusCode;
+        $this->responseBody = $responseBody;
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+
+    public function getResponseBody(): ?array
+    {
+        return $this->responseBody;
+    }
+}

--- a/src/Listclean/HttpClient.php
+++ b/src/Listclean/HttpClient.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Listclean;
+
+use Listclean\Exceptions\ApiException;
+
+class HttpClient
+{
+    /**
+     * @var string
+     */
+    private $baseUrl;
+
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    public function __construct(string $apiKey, string $baseUrl = 'https://api.listclean.xyz/v1/')
+    {
+        $this->apiKey = $apiKey;
+        $this->baseUrl = rtrim($baseUrl, '/') . '/';
+    }
+
+    /**
+     * @param string     $method
+     * @param string     $path
+     * @param array      $query
+     * @param array|null $body
+     * @param bool       $expectsJson
+     *
+     * @return array|string
+     *
+     * @throws ApiException
+     */
+    public function request(string $method, string $path, array $query = [], ?array $body = null, bool $expectsJson = true)
+    {
+        $url = $this->baseUrl . ltrim($path, '/');
+
+        if (!empty($query)) {
+            $url .= '?' . http_build_query($query);
+        }
+
+        $ch = curl_init($url);
+
+        if ($ch === false) {
+            throw new ApiException('Failed to initialize HTTP request.');
+        }
+
+        $headers = [
+            'Accept: application/json',
+            'X-Auth-Token: ' . $this->apiKey,
+        ];
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => strtoupper($method),
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_TIMEOUT => 30,
+        ]);
+
+        if ($body !== null) {
+            $encodedBody = json_encode($body);
+            if ($encodedBody === false) {
+                curl_close($ch);
+                throw new ApiException('Failed to encode request body as JSON.');
+            }
+
+            $headers[] = 'Content-Type: application/json';
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $encodedBody);
+        }
+
+        $response = curl_exec($ch);
+        $curlError = curl_error($ch);
+        $statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+
+        if ($response === false) {
+            throw new ApiException('HTTP request failed: ' . $curlError, $statusCode ?: 0);
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            $errorPayload = $expectsJson ? json_decode($response, true) : ['body' => $response];
+            throw new ApiException('API returned an error response.', $statusCode, $errorPayload);
+        }
+
+        if (!$expectsJson) {
+            return $response;
+        }
+
+        $decoded = json_decode($response, true);
+
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw new ApiException('Failed to decode JSON response: ' . json_last_error_msg(), $statusCode);
+        }
+
+        return $decoded ?? [];
+    }
+}

--- a/src/Listclean/Listclean.php
+++ b/src/Listclean/Listclean.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Listclean;
+
+use InvalidArgumentException;
+use Listclean\Exceptions\ApiException;
+
+class Listclean
+{
+    /**
+     * @var HttpClient
+     */
+    private $httpClient;
+
+    public function __construct(string $apiKey, string $baseUrl = 'https://api.listclean.xyz/v1/')
+    {
+        $this->httpClient = new HttpClient($apiKey, $baseUrl);
+    }
+
+    /**
+     * Verify a single email address.
+     *
+     * @throws ApiException
+     */
+    public function verifyEmail(string $email): array
+    {
+        if ($email === '') {
+            throw new InvalidArgumentException('Email address must not be empty.');
+        }
+
+        $encodedEmail = rawurlencode($email);
+
+        return $this->httpClient->request('GET', "verify/email/{$encodedEmail}");
+    }
+
+    /**
+     * Verify a batch of email addresses (max 3000 emails).
+     *
+     * @param string[] $emails
+     *
+     * @throws ApiException
+     */
+    public function verifyEmailBatch(array $emails): array
+    {
+        $emails = array_values(array_filter($emails, function ($email) {
+            return $email !== '';
+        }));
+
+        if (empty($emails)) {
+            throw new InvalidArgumentException('The emails array must contain at least one address.');
+        }
+
+        if (count($emails) > 3000) {
+            throw new InvalidArgumentException('The emails array cannot contain more than 3000 addresses.');
+        }
+
+        return $this->httpClient->request('POST', 'verify/email/batch', [], [
+            'emails' => $emails,
+        ]);
+    }
+
+    /**
+     * Fetch logs for previous single email verifications.
+     *
+     * @throws ApiException
+     */
+    public function getVerificationLogs(): array
+    {
+        return $this->httpClient->request('GET', 'verify/email/logs');
+    }
+
+    /**
+     * List uploads.
+     *
+     * @throws ApiException
+     */
+    public function listUploads(): array
+    {
+        return $this->httpClient->request('GET', 'uploads/');
+    }
+
+    /**
+     * Start a new CSV upload.
+     *
+     * @param array $payload
+     *
+     * @throws ApiException
+     */
+    public function startUpload(array $payload): array
+    {
+        return $this->httpClient->request('POST', 'uploads/', [], $payload);
+    }
+
+    /**
+     * Upload a chunk for an existing upload.
+     *
+     * @param int   $uploadId
+     * @param array $payload
+     *
+     * @throws ApiException
+     */
+    public function uploadChunk(int $uploadId, array $payload): array
+    {
+        return $this->httpClient->request('POST', "uploads/{$uploadId}", [], $payload);
+    }
+
+    /**
+     * Get the status of an upload.
+     *
+     * @throws ApiException
+     */
+    public function getUploadStatus(int $uploadId): array
+    {
+        return $this->httpClient->request('GET', "uploads/{$uploadId}");
+    }
+
+    /**
+     * Fetch all lists.
+     *
+     * @throws ApiException
+     */
+    public function listLists(): array
+    {
+        return $this->httpClient->request('GET', 'lists/');
+    }
+
+    /**
+     * Fetch a single list.
+     *
+     * @throws ApiException
+     */
+    public function getList(int $listId): array
+    {
+        return $this->httpClient->request('GET', "lists/{$listId}");
+    }
+
+    /**
+     * Delete a list.
+     *
+     * @throws ApiException
+     */
+    public function deleteList(int $listId): array
+    {
+        return $this->httpClient->request('DELETE', "lists/{$listId}");
+    }
+
+    /**
+     * Download list results as CSV.
+     *
+     * @throws ApiException
+     */
+    public function downloadListCsv(int $listId, string $type, ?string $tokenOverride = null): string
+    {
+        $type = $this->normalizeResultType($type);
+
+        $query = [];
+        if ($tokenOverride !== null) {
+            $query['X-Auth-Token'] = $tokenOverride;
+        }
+
+        return $this->httpClient->request('GET', "downloads/{$listId}/{$type}/", $query, null, false);
+    }
+
+    /**
+     * Download list results as JSON.
+     *
+     * @throws ApiException
+     */
+    public function downloadListJson(int $listId, string $type, ?string $tokenOverride = null): array
+    {
+        $type = $this->normalizeResultType($type);
+
+        $query = [];
+        if ($tokenOverride !== null) {
+            $query['X-Auth-Token'] = $tokenOverride;
+        }
+
+        return $this->httpClient->request('GET', "downloads/json/{$listId}/{$type}/", $query);
+    }
+
+    /**
+     * Retrieve account profile details.
+     *
+     * @throws ApiException
+     */
+    public function getProfile(): array
+    {
+        return $this->httpClient->request('GET', 'account/profile/');
+    }
+
+    /**
+     * Update account profile details.
+     *
+     * @throws ApiException
+     */
+    public function updateProfile(array $payload): array
+    {
+        return $this->httpClient->request('POST', 'account/profile/', [], $payload);
+    }
+
+    /**
+     * Fetch credit balance.
+     *
+     * @throws ApiException
+     */
+    public function getCredits(): array
+    {
+        return $this->httpClient->request('GET', 'credits');
+    }
+
+    private function normalizeResultType(string $type): string
+    {
+        $normalized = strtolower($type);
+        $allowed = ['clean', 'dirty', 'unknown'];
+
+        if (!in_array($normalized, $allowed, true)) {
+            throw new InvalidArgumentException('Type must be one of: ' . implode(', ', $allowed));
+        }
+
+        return $normalized;
+    }
+}


### PR DESCRIPTION
## Summary
- add Composer package metadata and PSR-4 autoloading for the SDK
- implement HttpClient, Listclean client wrapper, and ApiException helpers around Listclean endpoints
- document usage and provide runnable examples for email verification and uploads
- rename the `ListcleanClient` entrypoint to `Listclean` across source, docs, and examples for a simpler API name

## Testing
- find src examples -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68e0fef2a4c08326b392ea03ed1fa426